### PR TITLE
fixed career_type is not updating

### DIFF
--- a/app/Models/Career.php
+++ b/app/Models/Career.php
@@ -36,7 +36,8 @@ class Career extends Model
         'level',
         'experience',
         'department',
-        'companyId'
+        'companyId',
+		'career_type'
     ];
 
     protected $casts = [


### PR DESCRIPTION
This pull request includes a small change to the `app/Models/Career.php` file. The change adds a new attribute `career_type` to the list of fillable properties in the `Career` model.

* [`app/Models/Career.php`](diffhunk://#diff-530a878d1899a2434d467a051b046bc6c31cfba85af63a5c4520c8594d0954e2L39-R40): Added `career_type` to the fillable properties in the `Career` model.